### PR TITLE
Fix python2.7 get-pip errors

### DIFF
--- a/beckley/challenge/Dockerfile
+++ b/beckley/challenge/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 RUN apt-get update -y; \
     apt-get install -y apache2 python curl; \
     a2enmod cgi; \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; \
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py; \
     python get-pip.py; \
     pip install skyfield;
 

--- a/beckley/solver/Dockerfile
+++ b/beckley/solver/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 #Install Apache, Python, Curl. Enable CGI. Install PIP, use PIP to install skyfield
 RUN apt-get update -y; \
     apt-get install -y python curl python-dev git libssl-dev libffi-dev build-essential; \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; \
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py; \
     python get-pip.py; \
     pip install skyfield;\
     pip install --upgrade pwntools


### PR DESCRIPTION
The old get-pip.py URL used within the `beckley` challenge yields errors upon trying to build either image. This updates this old URL to the new one so the Dockerfile downloads the correct script.